### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,13 @@ Our pipeline provides multiple scripts.
 To quickly demo it using a dummy lexicon, run:
 
 ```bash
+git clone https://github.com/ZurichNLP/spoken-to-signed-translation
+cd spoken-to-signed-translation
+```
+
+```bash
 text_to_gloss_to_pose \
-  --text "Kleine Kinder essen Pizza" \
+  --text "Kleine Kinder essen Pizza." \
   --glosser "simple" \
   --lexicon "assets/dummy_lexicon" \
   --spoken-language "de" \
@@ -49,8 +54,8 @@ This script translates input text into gloss notation.
 text_to_gloss \
   --text <input_text> \
   --glosser <simple|rules|nmt> \
-  --spoken-language <de|fr|it|en> \
-  --signed-language <sgg|gsg|bfi>
+  --spoken-language <de|fr|it> \
+  --signed-language <sgg|fsl|ise>
 ```
 
 #### Pose-to-Video Conversion
@@ -72,8 +77,8 @@ text_to_gloss_to_pose \
   --text <input_text> \
   --glosser <simple|rules|nmt> \
   --lexicon <path_to_directory> \
-  --spoken-language <de|fr|it|en> \
-  --signed-language <sgg|gsg|bfi> \
+  --spoken-language <de|fr|it> \
+  --signed-language <sgg|fsl|ise> \
   --pose <output_pose_file_path>.pose
 ```
 
@@ -86,8 +91,8 @@ text_to_gloss_to_pose_to_video \
   --text <input_text> \
   --glosser <simple|rules|nmt> \
   --lexicon <path_to_directory> \
-  --spoken-language <de|fr|it|en> \
-  --signed-language <sgg|gsg|bfi> \
+  --spoken-language <de|fr|it> \
+  --signed-language <sgg|fsl|ise> \
   --video <output_video_file_path>.mp4
 ```
 
@@ -114,7 +119,7 @@ The pipeline consists of three main components:
 
 ## Supported Languages
 
-| Language                   | Lemmatizers Supported              | Lexicon Data Source                                  |
+| Language                   | Glossers Supported                 | Lexicon Data Source                                  |
 |----------------------------|------------------------------------|------------------------------------------------------|
 | Swiss German Sign Language | `simple`, `rules`                  | [SignSuisse (de)](https://signsuisse.sgb-fss.ch/de/) |
 | French Sign Language       | `simple`                           | [SignSuisse (fr)](https://signsuisse.sgb-fss.ch/fr/) |

--- a/README.md
+++ b/README.md
@@ -119,13 +119,13 @@ The pipeline consists of three main components:
 
 ## Supported Languages
 
-| Language                   | Glossers Supported                 | Lexicon Data Source                                  |
-|----------------------------|------------------------------------|------------------------------------------------------|
-| Swiss German Sign Language | `simple`, `rules`                  | [SignSuisse (de)](https://signsuisse.sgb-fss.ch/de/) |
-| French Sign Language       | `simple`                           | [SignSuisse (fr)](https://signsuisse.sgb-fss.ch/fr/) |
-| Italian Sign Language      | `simple`                           | [SignSuisse (it)](https://signsuisse.sgb-fss.ch/it/) |
-| German Sign Language       | `simple`, [`nmt`](TODO-model-link) | WordNet (Coming Soon)                                |
-| British Sign Language      | `simple`, [`nmt`](TODO-model-link) | WordNet (Coming Soon)                                |
+| Language                   | Glossers Supported                                                                                                                          | Lexicon Data Source                                  |
+|----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| Swiss German Sign Language | `simple`, `rules`,[`nmt`](https://github.com/ZurichNLP/spoken-to-signed-translation/tree/main/spoken_to_signed/text_to_gloss#nmt-component) | [SignSuisse (de)](https://signsuisse.sgb-fss.ch/de/) |
+| French Sign Language       | `simple`                                                                                                                                    | [SignSuisse (fr)](https://signsuisse.sgb-fss.ch/fr/) |
+| Italian Sign Language      | `simple`                                                                                                                                    | [SignSuisse (it)](https://signsuisse.sgb-fss.ch/it/) |
+| German Sign Language       | `simple`, [`nmt`](https://github.com/ZurichNLP/spoken-to-signed-translation/tree/main/spoken_to_signed/text_to_gloss#nmt-component)         | WordNet (Coming Soon)                                |
+| British Sign Language      | `simple`, [`nmt`](TODO-model-link)                                                                                                          | WordNet (Coming Soon)                                |
 
 
 ## Citation

--- a/spoken_to_signed/text_to_gloss/README.md
+++ b/spoken_to_signed/text_to_gloss/README.md
@@ -11,3 +11,37 @@ def text_to_gloss(text: str, language: str) -> Gloss:
 ```
 
 It should return a list of tuples, each containing the original word and its gloss.
+
+## `nmt` component
+
+Using this component means that the spoken language text is translated into a sequence of sign language glosses with
+a neural machine translation system.
+
+Currently, the only language pair that is supported is German (DE) and German Sign Language (DGS), but the same system
+can also be used to translate between DE and Swiss German Sign Language (DSGS).
+
+We provide a trained model for this that is downloaded automatically from our public file server.
+
+To reproduce the training of this model, follow some of the steps outlined in this repository:
+https://github.com/bricksdont/easier-gloss-translation (see this repository for more explanation and documentation):
+
+````bash
+git clone https://github.com/bricksdont/easier-gloss-translation
+cd easier-gloss-translation
+````
+
+````bash
+./scripts/setup/create_venv.sh
+````
+
+````bash
+./scripts/setup/install.sh
+````
+
+Then run **one experiment** defined in
+
+````bash
+./scripts/running/run_multilingual_models.sh
+````
+
+specifically, execute only the part "Multilingual 1: all German and DGS directions" in this script.


### PR DESCRIPTION
minor changes, such as:
- in the README list only the languages that are currently supported?
- In the example "Kleine Kinder essen Pizza" use a "." at the end, because the NMT system only works well with well-formed sentences. So this works better as an example
- more docs about the nmt component
- to try the dummy lexicon, the repo must first be cloned locally