### PR TITLE
Replace URL for nmt model

### DIFF
--- a/spoken_to_signed/text_to_gloss/nmt.py
+++ b/spoken_to_signed/text_to_gloss/nmt.py
@@ -53,7 +53,7 @@ def load_sockeye_models():
         "dgs_de": {
                          "model_path": os.path.join(MODELS_PATH, "dgs_de"),
                          "spm_path": os.path.join(MODELS_PATH, "dgs_de", spm_name),
-                         "url": "https://files.ifi.uzh.ch/cl/archiv/2022/easier/dgs_de.tar.gz"
+                         "url": "https://archive.cl.uzh.ch/cl-archive/2022/easier/dgs_de.tar.gz"
                         }
     }
 


### PR DESCRIPTION
The old URL to download the DE<->DGS model was dead, this is a replacement