### PR TITLE
[UPD] Ignore __pycache__ directories in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 spoken_to_signed.egg-info/
 .env
+__pycache__/


### PR DESCRIPTION
Add `__pycache__/` to `.gitignore` to avoid tracking Python bytecode cache directories.
