### PR TITLE
[NEW] Add CLI option to disable fingerspelling fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,38 @@ Color legend:
 - Orange: matched via fingerspelling
 - Red: not matched
 
+#### Bulk Text-to-Gloss-to-Pose Translation
+
+This script translates a file of sentences (one per line) into pose files in bulk.
+
+```bash
+text_to_gloss_to_pose_bulk \
+  --texts <input_text_file> \
+  --glosser <simple|spacylemma|rules|nmt> \
+  --lexicon <path_to_directory> \
+  --spoken-language <de|fr|it> \
+  --signed-language <sgg|ssr|slf> \
+  --output-dir <output_directory>
+```
+
+By default, one `.pose` file per sentence is written to `--output-dir` (named `000000.pose`, `000001.pose`, …).
+
+Use `--compacted-poses` to concatenate all poses into chunked files instead, together with a `metadata.tsv` mapping each sentence to its file and frame range:
+
+```bash
+text_to_gloss_to_pose_bulk \
+  --texts sentences.txt \
+  --glosser simple \
+  --lexicon assets/dummy_lexicon \
+  --spoken-language de \
+  --signed-language sgg \
+  --output-dir output/ \
+  --compacted-poses \
+  --max-frames-per-chunk 10000
+```
+
+Add `--coverage-stats <file.json>` to save aggregated per-token coverage statistics across all sentences.
+
 #### Text-to-Gloss-to-Pose-to-Video Translation
 
 This script translates input text into gloss notation, converts the glosses into a pose file, and then transforms the pose file into a video.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ text_to_gloss_to_pose \
   --pose <output_pose_file_path>.pose
 ```
 
+Add `--coverage-info` to print per-token lexicon coverage to stdout, or `--coverage-stats <file.json>` to save it to a JSON file.
+
+#### Visualizing Coverage
+
+The `scripts/visualize_coverage.py` script renders a coverage JSON file (produced by `--coverage-stats`) in the terminal, coloring each gloss token by how it was matched:
+
+```bash
+python scripts/visualize_coverage.py <coverage_file>.json
+```
+
+Color legend:
+- Green: matched via lexicon
+- Yellow: matched via language backup
+- Orange: matched via fingerspelling
+- Red: not matched
+
 #### Text-to-Gloss-to-Pose-to-Video Translation
 
 This script translates input text into gloss notation, converts the glosses into a pose file, and then transforms the pose file into a video.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,4 +86,5 @@ testpaths = ["spoken_to_signed", "tests"]
 download_lexicon = "spoken_to_signed.download_lexicon:main"
 text_to_gloss = "spoken_to_signed.bin:text_to_gloss"
 text_to_gloss_to_pose = "spoken_to_signed.bin:text_to_gloss_to_pose"
+text_to_gloss_to_pose_bulk = "spoken_to_signed.bin:text_to_gloss_to_pose_bulk"
 text_to_gloss_to_pose_to_video = "spoken_to_signed.bin:text_to_gloss_to_pose_to_video"

--- a/scripts/visualize_coverage.py
+++ b/scripts/visualize_coverage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Visualize gloss coverage from a JSON file produced by text_to_gloss_to_pose --coverage-stats."""
+
+import argparse
+import json
+
+# ANSI color codes
+_RESET = "\033[0m"
+_COLORS = {
+    "lexicon": "\033[92m",           # bright green
+    "language_backup": "\033[93m",   # bright yellow
+    "fingerspelling_backup": "\033[38;5;214m",  # orange (256-color)
+    None: "\033[91m",                # bright red
+}
+
+_LEGEND = [
+    ("lexicon", "matched via lexicon"),
+    ("language_backup", "matched via language backup"),
+    ("fingerspelling_backup", "matched via fingerspelling"),
+    (None, "not matched"),
+]
+
+
+def _colored(text: str, coverage_type) -> str:
+    return f"{_COLORS[coverage_type]}{text}{_RESET}"
+
+
+def _print_legend():
+    print("Legend:")
+    for coverage_type, label in _LEGEND:
+        print(f"  {_colored('■', coverage_type)} {label}")
+    print()
+
+
+def visualize(coverage_path: str):
+    with open(coverage_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    overall_coverage = data.get("coverage", 0.0)
+    matched = data.get("matched_tokens", 0)
+    total = data.get("total_tokens", 0)
+
+    _print_legend()
+
+    for sentence in data["sentences"]:
+        sentence_text = sentence.get("text") or " ".join(t["word"] for t in sentence["tokens"] if t.get("word"))
+        colored_glosses = " ".join(
+            _colored(t["gloss"], t.get("coverage_type")) for t in sentence["tokens"]
+        )
+        print(f"Sentence: {sentence_text}")
+        print(f"Gloss:    {colored_glosses}")
+        print()
+
+    print(f"Overall coverage: {overall_coverage:.3f} ({matched}/{total} tokens matched)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visualize gloss coverage from a JSON coverage file.")
+    parser.add_argument("coverage_json", help="Path to the coverage JSON file.")
+    args = parser.parse_args()
+
+    visualize(args.coverage_json)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/visualize_coverage.py
+++ b/scripts/visualize_coverage.py
@@ -7,17 +7,17 @@ import json
 # ANSI color codes
 _RESET = "\033[0m"
 _COLORS = {
-    "lexicon": "\033[92m",           # bright green
-    "language_backup": "\033[93m",   # bright yellow
+    "lexicon":               "\033[92m",        # bright green
+    "language_backup":       "\033[93m",        # bright yellow
     "fingerspelling_backup": "\033[38;5;214m",  # orange (256-color)
-    None: "\033[91m",                # bright red
+    "unmatched":             "\033[91m",        # bright red
 }
 
 _LEGEND = [
-    ("lexicon", "matched via lexicon"),
-    ("language_backup", "matched via language backup"),
+    ("lexicon",               "matched via lexicon"),
+    ("language_backup",       "matched via language backup"),
     ("fingerspelling_backup", "matched via fingerspelling"),
-    (None, "not matched"),
+    ("unmatched",             "not matched"),
 ]
 
 
@@ -45,7 +45,7 @@ def visualize(coverage_path: str):
     for sentence in data["sentences"]:
         sentence_text = sentence.get("text") or " ".join(t["word"] for t in sentence["tokens"] if t.get("word"))
         colored_glosses = " ".join(
-            _colored(t["gloss"], t.get("coverage_type")) for t in sentence["tokens"]
+            _colored(t["gloss"], t.get("coverage_type") or "unmatched") for t in sentence["tokens"]
         )
         print(f"Sentence: {sentence_text}")
         print(f"Gloss:    {colored_glosses}")

--- a/spoken_to_signed/bin.py
+++ b/spoken_to_signed/bin.py
@@ -11,6 +11,7 @@ from spoken_to_signed.gloss_to_pose import (
     concatenate_poses,
     gloss_to_pose,
 )
+from spoken_to_signed.gloss_to_pose.coverage import CoverageStats, TokenCoverage
 from spoken_to_signed.gloss_to_pose.lookup.fingerspelling_lookup import (
     FingerspellingPoseLookup,
 )
@@ -22,13 +23,30 @@ def _text_to_gloss(text: str, language: str, glosser: str, **kwargs) -> list[Glo
     return module.text_to_gloss(text=text, language=language, **kwargs)
 
 
-def _gloss_to_pose(sentences: list[Gloss], lexicon: str, spoken_language: str, signed_language: str) -> Pose:
+def _gloss_to_pose(
+    sentences: list[Gloss],
+    lexicon: str,
+    spoken_language: str,
+    signed_language: str,
+    coverage_info: bool = False,
+) -> "Pose | tuple[Pose, list[list[TokenCoverage]]]":
     fingerspelling_lookup = FingerspellingPoseLookup()
     pose_lookup = CSVPoseLookup(lexicon, backup=fingerspelling_lookup)
-    poses = [gloss_to_pose(gloss, pose_lookup, spoken_language, signed_language) for gloss in sentences]
-    if len(poses) == 1:
-        return poses[0]
-    return concatenate_poses(poses, trim=False)
+    results = [
+        gloss_to_pose(gloss, pose_lookup, spoken_language, signed_language, coverage_info=coverage_info)
+        for gloss in sentences
+    ]
+
+    if not coverage_info:
+        poses = results
+        return poses[0] if len(poses) == 1 else concatenate_poses(poses, trim=False)
+
+    poses = [pose for pose, _ in results]
+    all_token_coverages = [coverages for _, coverages in results]
+    return (
+        poses[0] if len(poses) == 1 else concatenate_poses(poses, trim=False),
+        all_token_coverages,
+    )
 
 
 def _get_models_dir():
@@ -128,22 +146,57 @@ def pose_to_video():
     print("Output video:", args.video)
 
 
+def _print_token_coverage(all_token_coverages: list[list[TokenCoverage]]):
+    total = sum(len(s) for s in all_token_coverages)
+    matched = sum(tc.matched for s in all_token_coverages for tc in s)
+    for sentence_coverages in all_token_coverages:
+        for tc in sentence_coverages:
+            status = "✓" if tc.matched else "✗"
+            print(f"  {status}  {tc.word} -> {tc.gloss}")
+    print(f"Coverage: {matched / total:.3f} ({matched}/{total} tokens matched)")
+
+
 def text_to_gloss_to_pose():
     args_parser = argparse.ArgumentParser()
     _text_input_arguments(args_parser)
     args_parser.add_argument("--lexicon", type=str, required=True)
+    args_parser.add_argument(
+        "--coverage-info",
+        action="store_true",
+        help="Print per-token gloss coverage to stdout.",
+    )
+    args_parser.add_argument(
+        "--coverage-stats",
+        type=str,
+        default=None,
+        help="Path to save per-token coverage statistics as a JSON file.",
+    )
     args_parser.add_argument("--pose", type=str, required=True)
     args = args_parser.parse_args()
 
-    sentences = _text_to_gloss(args.text, args.spoken_language, args.glosser)
-    pose = _gloss_to_pose(sentences, args.lexicon, args.spoken_language, args.signed_language)
+    need_coverage = args.coverage_info or args.coverage_stats is not None
 
-    with open(args.pose, "wb") as f:
-        pose.write(f)
+    sentences = _text_to_gloss(args.text, args.spoken_language, args.glosser)
+    result = _gloss_to_pose(sentences, args.lexicon, args.spoken_language, args.signed_language, need_coverage)
 
     print("Text to gloss to pose")
     print("Input text:", args.text)
     print("Output pose:", args.pose)
+
+    if need_coverage:
+        pose, all_token_coverages = result
+        _print_token_coverage(all_token_coverages)
+        if args.coverage_stats:
+            stats = CoverageStats()
+            for sentence_coverages in all_token_coverages:
+                stats.add_sentence(sentence_coverages, text=args.text)
+            stats.save(args.coverage_stats)
+            print(f"Coverage stats saved to: {args.coverage_stats}")
+    else:
+        pose = result
+
+    with open(args.pose, "wb") as f:
+        pose.write(f)
 
 
 def text_to_gloss_to_pose_to_video():

--- a/spoken_to_signed/bin.py
+++ b/spoken_to_signed/bin.py
@@ -1,10 +1,13 @@
 import argparse
+import csv
 import importlib
 import os
 import tempfile
 from itertools import chain
 
+import numpy as np
 from pose_format import Pose
+from pose_format.numpy import NumPyPoseBody
 
 from spoken_to_signed.gloss_to_pose import (
     CSVPoseLookup,
@@ -193,6 +196,147 @@ def text_to_gloss_to_pose():
 
     with open(args.pose, "wb") as f:
         result.pose.write(f)
+
+
+def _raw_concatenate_poses(poses: list[Pose]) -> Pose:
+    new_data = np.concatenate([pose.body.data for pose in poses])
+    new_conf = np.concatenate([pose.body.confidence for pose in poses])
+    new_body = NumPyPoseBody(fps=poses[0].body.fps, data=new_data, confidence=new_conf)
+    return Pose(header=poses[0].header, body=new_body)
+
+
+def _write_chunk(chunk_poses: list[Pose], chunk_path: str):
+    chunk_pose = _raw_concatenate_poses(chunk_poses) if len(chunk_poses) > 1 else chunk_poses[0]
+    with open(chunk_path, "wb") as f:
+        chunk_pose.write(f)
+
+
+def _process_pose(text, spoken_language, glosser, pose_lookup, signed_language, need_coverage, stats):
+    sentences = _text_to_gloss(text, spoken_language, glosser)
+    results = [
+        gloss_to_pose(gloss, pose_lookup, spoken_language, signed_language, coverage_info=need_coverage)
+        for gloss in sentences
+    ]
+    if need_coverage:
+        poses = [pose for pose, _ in results]
+        all_token_coverages = [coverages for _, coverages in results]
+        for sentence_coverages in all_token_coverages:
+            stats.add_sentence(sentence_coverages, text=text)
+    else:
+        poses = results
+    return poses[0] if len(poses) == 1 else concatenate_poses(poses, trim=False)
+
+
+def _bulk_sequential(texts, args, pose_lookup, need_coverage, stats):
+    for i, text in enumerate(texts):
+        pose = _process_pose(
+            text, args.spoken_language, args.glosser, pose_lookup, args.signed_language, need_coverage, stats
+        )
+        pose_path = os.path.join(args.output_dir, f"{i:06d}.pose")
+        with open(pose_path, "wb") as f:
+            pose.write(f)
+        print(f"[{i + 1}/{len(texts)}] {pose_path}")
+
+
+def _bulk_compacted(texts, args, pose_lookup, need_coverage, stats):
+    metadata_rows: list[dict] = []
+    chunk_index = 0
+    chunk_poses: list[Pose] = []
+    chunk_frame_count = 0
+
+    for i, text in enumerate(texts):
+        pose = _process_pose(
+            text, args.spoken_language, args.glosser, pose_lookup, args.signed_language, need_coverage, stats
+        )
+        pose_frames = len(pose.body.data)
+
+        # Flush current chunk if adding this pose would exceed the limit (keep at least one pose per chunk)
+        if chunk_poses and chunk_frame_count + pose_frames > args.max_frames_per_chunk:
+            chunk_path = os.path.join(args.output_dir, f"chunk_{chunk_index:06d}.pose")
+            _write_chunk(chunk_poses, chunk_path)
+            print(f"  Saved chunk {chunk_index}: {chunk_path} ({chunk_frame_count} frames)")
+            chunk_index += 1
+            chunk_poses = []
+            chunk_frame_count = 0
+
+        start_frame = chunk_frame_count
+        end_frame = chunk_frame_count + pose_frames - 1
+        chunk_path = os.path.join(args.output_dir, f"chunk_{chunk_index:06d}.pose")
+        metadata_rows.append(
+            {"text": text, "pose_file": os.path.abspath(chunk_path), "start_frame": start_frame, "end_frame": end_frame}
+        )
+        chunk_poses.append(pose)
+        chunk_frame_count += pose_frames
+        print(f"[{i + 1}/{len(texts)}] buffered into {chunk_path} frames {start_frame}–{end_frame}")
+
+    # Write the last chunk
+    if chunk_poses:
+        chunk_path = os.path.join(args.output_dir, f"chunk_{chunk_index:06d}.pose")
+        _write_chunk(chunk_poses, chunk_path)
+        print(f"  Saved chunk {chunk_index}: {chunk_path} ({chunk_frame_count} frames)")
+
+    # Write metadata TSV
+    metadata_path = os.path.join(args.output_dir, "metadata.tsv")
+    with open(metadata_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["text", "pose_file", "start_frame", "end_frame"], delimiter="\t")
+        writer.writeheader()
+        writer.writerows(metadata_rows)
+    print(f"Metadata saved to: {metadata_path}")
+
+
+def text_to_gloss_to_pose_bulk():
+    args_parser = argparse.ArgumentParser(
+        description="Translate a file of texts (one per line) into pose files in bulk."
+    )
+    args_parser.add_argument("--texts", type=str, required=True, help="Path to a text file with one sentence per line.")
+    args_parser.add_argument("--glosser", choices=["simple", "spacylemma", "rules", "nmt"], required=True)
+    args_parser.add_argument("--lexicon", type=str, required=True)
+    args_parser.add_argument("--spoken-language", type=str, required=True)
+    args_parser.add_argument("--signed-language", type=str, required=True)
+    args_parser.add_argument(
+        "--output-dir",
+        type=str,
+        required=True,
+        help="Directory where output .pose files are written (named 000000.pose, 000001.pose, …).",
+    )
+    args_parser.add_argument(
+        "--coverage-stats",
+        type=str,
+        default=None,
+        help="Path to save aggregated per-token coverage statistics as a JSON file.",
+    )
+    args_parser.add_argument(
+        "--compacted-poses",
+        action="store_true",
+        help="Concatenate generated poses into chunks instead of saving one file per sentence.",
+    )
+    args_parser.add_argument(
+        "--max-frames-per-chunk",
+        type=int,
+        default=10000,
+        help="Maximum number of frames per chunk when --compacted-poses is set (default: 10000).",
+    )
+    args = args_parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    with open(args.texts, encoding="utf-8") as f:
+        texts = [line.rstrip("\n") for line in f if line.strip()]
+
+    need_coverage = args.coverage_stats is not None
+    stats = CoverageStats() if need_coverage else None
+    fingerspelling_lookup = FingerspellingPoseLookup()
+    pose_lookup = CSVPoseLookup(args.lexicon, backup=fingerspelling_lookup)
+
+    if args.compacted_poses:
+        _bulk_compacted(texts, args, pose_lookup, need_coverage, stats)
+    else:
+        _bulk_sequential(texts, args, pose_lookup, need_coverage, stats)
+
+    if need_coverage:
+        stats.save(args.coverage_stats)
+        print(f"Coverage stats saved to: {args.coverage_stats}")
+        print(f"Overall coverage: {stats.fraction:.3f} ({stats.matched_tokens}/{stats.total_tokens} tokens matched)")
 
 
 def text_to_gloss_to_pose_to_video():

--- a/spoken_to_signed/bin.py
+++ b/spoken_to_signed/bin.py
@@ -148,10 +148,10 @@ def pose_to_video():
 
 def _print_token_coverage(all_token_coverages: list[list[TokenCoverage]]):
     total = sum(len(s) for s in all_token_coverages)
-    matched = sum(tc.matched for s in all_token_coverages for tc in s)
+    matched = sum(tc.exact_lexicon_match for s in all_token_coverages for tc in s)
     for sentence_coverages in all_token_coverages:
         for tc in sentence_coverages:
-            status = "✓" if tc.matched else "✗"
+            status = "✓" if tc.exact_lexicon_match else "✗"
             print(f"  {status}  {tc.word} -> {tc.gloss}")
     print(f"Coverage: {matched / total:.3f} ({matched}/{total} tokens matched)")
 

--- a/spoken_to_signed/bin.py
+++ b/spoken_to_signed/bin.py
@@ -336,6 +336,147 @@ def text_to_gloss_to_pose_bulk():
         print(f"Overall coverage: {stats.fraction:.3f} ({stats.matched_tokens}/{stats.total_tokens} tokens matched)")
 
 
+def _raw_concatenate_poses(poses: list[Pose]) -> Pose:
+    new_data = np.concatenate([pose.body.data for pose in poses])
+    new_conf = np.concatenate([pose.body.confidence for pose in poses])
+    new_body = NumPyPoseBody(fps=poses[0].body.fps, data=new_data, confidence=new_conf)
+    return Pose(header=poses[0].header, body=new_body)
+
+
+def _write_chunk(chunk_poses: list[Pose], chunk_path: str):
+    chunk_pose = _raw_concatenate_poses(chunk_poses) if len(chunk_poses) > 1 else chunk_poses[0]
+    with open(chunk_path, "wb") as f:
+        chunk_pose.write(f)
+
+
+def _process_pose(text, spoken_language, glosser, pose_lookup, signed_language, need_coverage, stats):
+    sentences = _text_to_gloss(text, spoken_language, glosser)
+    results = [
+        gloss_to_pose(gloss, pose_lookup, spoken_language, signed_language, coverage_info=need_coverage)
+        for gloss in sentences
+    ]
+    if need_coverage:
+        poses = [pose for pose, _ in results]
+        all_token_coverages = [coverages for _, coverages in results]
+        for sentence_coverages in all_token_coverages:
+            stats.add_sentence(sentence_coverages, text=text)
+    else:
+        poses = results
+    return poses[0] if len(poses) == 1 else concatenate_poses(poses, trim=False)
+
+
+def _bulk_sequential(texts, args, pose_lookup, need_coverage, stats):
+    for i, text in enumerate(texts):
+        pose = _process_pose(
+            text, args.spoken_language, args.glosser, pose_lookup, args.signed_language, need_coverage, stats
+        )
+        pose_path = os.path.join(args.output_dir, f"{i:06d}.pose")
+        with open(pose_path, "wb") as f:
+            pose.write(f)
+        print(f"[{i + 1}/{len(texts)}] {pose_path}")
+
+
+def _bulk_compacted(texts, args, pose_lookup, need_coverage, stats):
+    metadata_rows: list[dict] = []
+    chunk_index = 0
+    chunk_poses: list[Pose] = []
+    chunk_frame_count = 0
+
+    for i, text in enumerate(texts):
+        pose = _process_pose(
+            text, args.spoken_language, args.glosser, pose_lookup, args.signed_language, need_coverage, stats
+        )
+        pose_frames = len(pose.body.data)
+
+        # Flush current chunk if adding this pose would exceed the limit (keep at least one pose per chunk)
+        if chunk_poses and chunk_frame_count + pose_frames > args.max_frames_per_chunk:
+            chunk_path = os.path.join(args.output_dir, f"chunk_{chunk_index:06d}.pose")
+            _write_chunk(chunk_poses, chunk_path)
+            print(f"  Saved chunk {chunk_index}: {chunk_path} ({chunk_frame_count} frames)")
+            chunk_index += 1
+            chunk_poses = []
+            chunk_frame_count = 0
+
+        start_frame = chunk_frame_count
+        end_frame = chunk_frame_count + pose_frames - 1
+        chunk_path = os.path.join(args.output_dir, f"chunk_{chunk_index:06d}.pose")
+        metadata_rows.append(
+            {"text": text, "pose_file": os.path.abspath(chunk_path), "start_frame": start_frame, "end_frame": end_frame}
+        )
+        chunk_poses.append(pose)
+        chunk_frame_count += pose_frames
+        print(f"[{i + 1}/{len(texts)}] buffered into {chunk_path} frames {start_frame}–{end_frame}")
+
+    # Write the last chunk
+    if chunk_poses:
+        chunk_path = os.path.join(args.output_dir, f"chunk_{chunk_index:06d}.pose")
+        _write_chunk(chunk_poses, chunk_path)
+        print(f"  Saved chunk {chunk_index}: {chunk_path} ({chunk_frame_count} frames)")
+
+    # Write metadata TSV
+    metadata_path = os.path.join(args.output_dir, "metadata.tsv")
+    with open(metadata_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["text", "pose_file", "start_frame", "end_frame"], delimiter="\t")
+        writer.writeheader()
+        writer.writerows(metadata_rows)
+    print(f"Metadata saved to: {metadata_path}")
+
+
+def text_to_gloss_to_pose_bulk():
+    args_parser = argparse.ArgumentParser(
+        description="Translate a file of texts (one per line) into pose files in bulk."
+    )
+    args_parser.add_argument("--texts", type=str, required=True, help="Path to a text file with one sentence per line.")
+    args_parser.add_argument("--glosser", choices=["simple", "spacylemma", "rules", "nmt"], required=True)
+    args_parser.add_argument("--lexicon", type=str, required=True)
+    args_parser.add_argument("--spoken-language", type=str, required=True)
+    args_parser.add_argument("--signed-language", type=str, required=True)
+    args_parser.add_argument(
+        "--output-dir",
+        type=str,
+        required=True,
+        help="Directory where output .pose files are written (named 000000.pose, 000001.pose, …).",
+    )
+    args_parser.add_argument(
+        "--coverage-stats",
+        type=str,
+        default=None,
+        help="Path to save aggregated per-token coverage statistics as a JSON file.",
+    )
+    args_parser.add_argument(
+        "--compacted-poses",
+        action="store_true",
+        help="Concatenate generated poses into chunks instead of saving one file per sentence.",
+    )
+    args_parser.add_argument(
+        "--max-frames-per-chunk",
+        type=int,
+        default=10000,
+        help="Maximum number of frames per chunk when --compacted-poses is set (default: 10000).",
+    )
+    args = args_parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    with open(args.texts, encoding="utf-8") as f:
+        texts = [line.rstrip("\n") for line in f if line.strip()]
+
+    need_coverage = args.coverage_stats is not None
+    stats = CoverageStats() if need_coverage else None
+    fingerspelling_lookup = FingerspellingPoseLookup()
+    pose_lookup = CSVPoseLookup(args.lexicon, backup=fingerspelling_lookup)
+
+    if args.compacted_poses:
+        _bulk_compacted(texts, args, pose_lookup, need_coverage, stats)
+    else:
+        _bulk_sequential(texts, args, pose_lookup, need_coverage, stats)
+
+    if need_coverage:
+        stats.save(args.coverage_stats)
+        print(f"Coverage stats saved to: {args.coverage_stats}")
+        print(f"Overall coverage: {stats.fraction:.3f} ({stats.matched_tokens}/{stats.total_tokens} tokens matched)")
+
+
 def text_to_gloss_to_pose_to_video():
     args_parser = argparse.ArgumentParser()
     _text_input_arguments(args_parser)

--- a/spoken_to_signed/bin.py
+++ b/spoken_to_signed/bin.py
@@ -203,8 +203,8 @@ def text_to_gloss_to_pose_to_video():
     args = args_parser.parse_args()
 
     sentences = _text_to_gloss(args.text, args.spoken_language, args.glosser, signed_language=args.signed_language)
-    pose = _gloss_to_pose(sentences, args.lexicon, args.spoken_language, args.signed_language)
-    _pose_to_video(pose, args.video)
+    result = _gloss_to_pose(sentences, args.lexicon, args.spoken_language, args.signed_language)
+    _pose_to_video(result.pose, args.video)
 
     print("Text to gloss to pose to video")
     print("Input text:", args.text)

--- a/spoken_to_signed/bin.py
+++ b/spoken_to_signed/bin.py
@@ -217,13 +217,10 @@ def _process_pose(text, spoken_language, glosser, pose_lookup, signed_language, 
         gloss_to_pose(gloss, pose_lookup, spoken_language, signed_language, coverage_info=need_coverage)
         for gloss in sentences
     ]
+    poses = [r.pose for r in results]
     if need_coverage:
-        poses = [pose for pose, _ in results]
-        all_token_coverages = [coverages for _, coverages in results]
-        for sentence_coverages in all_token_coverages:
-            stats.add_sentence(sentence_coverages, text=text)
-    else:
-        poses = results
+        for r in results:
+            stats.add_sentence(r.token_coverages, text=text)
     return poses[0] if len(poses) == 1 else concatenate_poses(poses, trim=False)
 
 

--- a/spoken_to_signed/bin.py
+++ b/spoken_to_signed/bin.py
@@ -8,6 +8,7 @@ from pose_format import Pose
 
 from spoken_to_signed.gloss_to_pose import (
     CSVPoseLookup,
+    GlossToPoseResult,
     concatenate_poses,
     gloss_to_pose,
 )
@@ -29,7 +30,7 @@ def _gloss_to_pose(
     spoken_language: str,
     signed_language: str,
     coverage_info: bool = False,
-) -> "Pose | tuple[Pose, list[list[TokenCoverage]]]":
+) -> GlossToPoseResult:
     fingerspelling_lookup = FingerspellingPoseLookup()
     pose_lookup = CSVPoseLookup(lexicon, backup=fingerspelling_lookup)
     results = [
@@ -37,16 +38,14 @@ def _gloss_to_pose(
         for gloss in sentences
     ]
 
-    if not coverage_info:
-        poses = results
-        return poses[0] if len(poses) == 1 else concatenate_poses(poses, trim=False)
+    poses = [r.pose for r in results]
+    pose = poses[0] if len(poses) == 1 else concatenate_poses(poses, trim=False)
 
-    poses = [pose for pose, _ in results]
-    all_token_coverages = [coverages for _, coverages in results]
-    return (
-        poses[0] if len(poses) == 1 else concatenate_poses(poses, trim=False),
-        all_token_coverages,
-    )
+    if coverage_info:
+        all_token_coverages = [r.token_coverages for r in results]
+        return GlossToPoseResult(pose=pose, token_coverages=all_token_coverages)
+
+    return GlossToPoseResult(pose=pose)
 
 
 def _get_models_dir():
@@ -184,19 +183,16 @@ def text_to_gloss_to_pose():
     print("Output pose:", args.pose)
 
     if need_coverage:
-        pose, all_token_coverages = result
-        _print_token_coverage(all_token_coverages)
+        _print_token_coverage(result.token_coverages)
         if args.coverage_stats:
             stats = CoverageStats()
-            for sentence_coverages in all_token_coverages:
+            for sentence_coverages in result.token_coverages:
                 stats.add_sentence(sentence_coverages, text=args.text)
             stats.save(args.coverage_stats)
             print(f"Coverage stats saved to: {args.coverage_stats}")
-    else:
-        pose = result
 
     with open(args.pose, "wb") as f:
-        pose.write(f)
+        result.pose.write(f)
 
 
 def text_to_gloss_to_pose_to_video():

--- a/spoken_to_signed/bin.py
+++ b/spoken_to_signed/bin.py
@@ -33,8 +33,9 @@ def _gloss_to_pose(
     spoken_language: str,
     signed_language: str,
     coverage_info: bool = False,
+    use_fingerspelling: bool = True,
 ) -> GlossToPoseResult:
-    fingerspelling_lookup = FingerspellingPoseLookup()
+    fingerspelling_lookup = FingerspellingPoseLookup() if use_fingerspelling else None
     pose_lookup = CSVPoseLookup(lexicon, backup=fingerspelling_lookup)
     results = [
         gloss_to_pose(gloss, pose_lookup, spoken_language, signed_language, coverage_info=coverage_info)
@@ -174,12 +175,20 @@ def text_to_gloss_to_pose():
         help="Path to save per-token coverage statistics as a JSON file.",
     )
     args_parser.add_argument("--pose", type=str, required=True)
+    args_parser.add_argument(
+        "--no-fingerspelling",
+        action="store_true",
+        help="Disable fingerspelling fallback during pose lookup.",
+    )
     args = args_parser.parse_args()
 
     need_coverage = args.coverage_info or args.coverage_stats is not None
 
     sentences = _text_to_gloss(args.text, args.spoken_language, args.glosser)
-    result = _gloss_to_pose(sentences, args.lexicon, args.spoken_language, args.signed_language, need_coverage)
+    result = _gloss_to_pose(
+        sentences, args.lexicon, args.spoken_language, args.signed_language, need_coverage,
+        use_fingerspelling=not args.no_fingerspelling
+    )
 
     print("Text to gloss to pose")
     print("Input text:", args.text)
@@ -313,146 +322,10 @@ def text_to_gloss_to_pose_bulk():
         default=10000,
         help="Maximum number of frames per chunk when --compacted-poses is set (default: 10000).",
     )
-    args = args_parser.parse_args()
-
-    os.makedirs(args.output_dir, exist_ok=True)
-
-    with open(args.texts, encoding="utf-8") as f:
-        texts = [line.rstrip("\n") for line in f if line.strip()]
-
-    need_coverage = args.coverage_stats is not None
-    stats = CoverageStats() if need_coverage else None
-    fingerspelling_lookup = FingerspellingPoseLookup()
-    pose_lookup = CSVPoseLookup(args.lexicon, backup=fingerspelling_lookup)
-
-    if args.compacted_poses:
-        _bulk_compacted(texts, args, pose_lookup, need_coverage, stats)
-    else:
-        _bulk_sequential(texts, args, pose_lookup, need_coverage, stats)
-
-    if need_coverage:
-        stats.save(args.coverage_stats)
-        print(f"Coverage stats saved to: {args.coverage_stats}")
-        print(f"Overall coverage: {stats.fraction:.3f} ({stats.matched_tokens}/{stats.total_tokens} tokens matched)")
-
-
-def _raw_concatenate_poses(poses: list[Pose]) -> Pose:
-    new_data = np.concatenate([pose.body.data for pose in poses])
-    new_conf = np.concatenate([pose.body.confidence for pose in poses])
-    new_body = NumPyPoseBody(fps=poses[0].body.fps, data=new_data, confidence=new_conf)
-    return Pose(header=poses[0].header, body=new_body)
-
-
-def _write_chunk(chunk_poses: list[Pose], chunk_path: str):
-    chunk_pose = _raw_concatenate_poses(chunk_poses) if len(chunk_poses) > 1 else chunk_poses[0]
-    with open(chunk_path, "wb") as f:
-        chunk_pose.write(f)
-
-
-def _process_pose(text, spoken_language, glosser, pose_lookup, signed_language, need_coverage, stats):
-    sentences = _text_to_gloss(text, spoken_language, glosser)
-    results = [
-        gloss_to_pose(gloss, pose_lookup, spoken_language, signed_language, coverage_info=need_coverage)
-        for gloss in sentences
-    ]
-    if need_coverage:
-        poses = [pose for pose, _ in results]
-        all_token_coverages = [coverages for _, coverages in results]
-        for sentence_coverages in all_token_coverages:
-            stats.add_sentence(sentence_coverages, text=text)
-    else:
-        poses = results
-    return poses[0] if len(poses) == 1 else concatenate_poses(poses, trim=False)
-
-
-def _bulk_sequential(texts, args, pose_lookup, need_coverage, stats):
-    for i, text in enumerate(texts):
-        pose = _process_pose(
-            text, args.spoken_language, args.glosser, pose_lookup, args.signed_language, need_coverage, stats
-        )
-        pose_path = os.path.join(args.output_dir, f"{i:06d}.pose")
-        with open(pose_path, "wb") as f:
-            pose.write(f)
-        print(f"[{i + 1}/{len(texts)}] {pose_path}")
-
-
-def _bulk_compacted(texts, args, pose_lookup, need_coverage, stats):
-    metadata_rows: list[dict] = []
-    chunk_index = 0
-    chunk_poses: list[Pose] = []
-    chunk_frame_count = 0
-
-    for i, text in enumerate(texts):
-        pose = _process_pose(
-            text, args.spoken_language, args.glosser, pose_lookup, args.signed_language, need_coverage, stats
-        )
-        pose_frames = len(pose.body.data)
-
-        # Flush current chunk if adding this pose would exceed the limit (keep at least one pose per chunk)
-        if chunk_poses and chunk_frame_count + pose_frames > args.max_frames_per_chunk:
-            chunk_path = os.path.join(args.output_dir, f"chunk_{chunk_index:06d}.pose")
-            _write_chunk(chunk_poses, chunk_path)
-            print(f"  Saved chunk {chunk_index}: {chunk_path} ({chunk_frame_count} frames)")
-            chunk_index += 1
-            chunk_poses = []
-            chunk_frame_count = 0
-
-        start_frame = chunk_frame_count
-        end_frame = chunk_frame_count + pose_frames - 1
-        chunk_path = os.path.join(args.output_dir, f"chunk_{chunk_index:06d}.pose")
-        metadata_rows.append(
-            {"text": text, "pose_file": os.path.abspath(chunk_path), "start_frame": start_frame, "end_frame": end_frame}
-        )
-        chunk_poses.append(pose)
-        chunk_frame_count += pose_frames
-        print(f"[{i + 1}/{len(texts)}] buffered into {chunk_path} frames {start_frame}–{end_frame}")
-
-    # Write the last chunk
-    if chunk_poses:
-        chunk_path = os.path.join(args.output_dir, f"chunk_{chunk_index:06d}.pose")
-        _write_chunk(chunk_poses, chunk_path)
-        print(f"  Saved chunk {chunk_index}: {chunk_path} ({chunk_frame_count} frames)")
-
-    # Write metadata TSV
-    metadata_path = os.path.join(args.output_dir, "metadata.tsv")
-    with open(metadata_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=["text", "pose_file", "start_frame", "end_frame"], delimiter="\t")
-        writer.writeheader()
-        writer.writerows(metadata_rows)
-    print(f"Metadata saved to: {metadata_path}")
-
-
-def text_to_gloss_to_pose_bulk():
-    args_parser = argparse.ArgumentParser(
-        description="Translate a file of texts (one per line) into pose files in bulk."
-    )
-    args_parser.add_argument("--texts", type=str, required=True, help="Path to a text file with one sentence per line.")
-    args_parser.add_argument("--glosser", choices=["simple", "spacylemma", "rules", "nmt"], required=True)
-    args_parser.add_argument("--lexicon", type=str, required=True)
-    args_parser.add_argument("--spoken-language", type=str, required=True)
-    args_parser.add_argument("--signed-language", type=str, required=True)
     args_parser.add_argument(
-        "--output-dir",
-        type=str,
-        required=True,
-        help="Directory where output .pose files are written (named 000000.pose, 000001.pose, …).",
-    )
-    args_parser.add_argument(
-        "--coverage-stats",
-        type=str,
-        default=None,
-        help="Path to save aggregated per-token coverage statistics as a JSON file.",
-    )
-    args_parser.add_argument(
-        "--compacted-poses",
+        "--no-fingerspelling",
         action="store_true",
-        help="Concatenate generated poses into chunks instead of saving one file per sentence.",
-    )
-    args_parser.add_argument(
-        "--max-frames-per-chunk",
-        type=int,
-        default=10000,
-        help="Maximum number of frames per chunk when --compacted-poses is set (default: 10000).",
+        help="Disable fingerspelling fallback during pose lookup.",
     )
     args = args_parser.parse_args()
 
@@ -463,7 +336,7 @@ def text_to_gloss_to_pose_bulk():
 
     need_coverage = args.coverage_stats is not None
     stats = CoverageStats() if need_coverage else None
-    fingerspelling_lookup = FingerspellingPoseLookup()
+    fingerspelling_lookup = FingerspellingPoseLookup() if not args.no_fingerspelling else None
     pose_lookup = CSVPoseLookup(args.lexicon, backup=fingerspelling_lookup)
 
     if args.compacted_poses:
@@ -482,10 +355,16 @@ def text_to_gloss_to_pose_to_video():
     _text_input_arguments(args_parser)
     args_parser.add_argument("--lexicon", type=str, required=True)
     args_parser.add_argument("--video", type=str, required=True)
+    args_parser.add_argument(
+        "--no-fingerspelling",
+        action="store_true",
+        help="Disable fingerspelling fallback during pose lookup.",
+    )
     args = args_parser.parse_args()
 
     sentences = _text_to_gloss(args.text, args.spoken_language, args.glosser, signed_language=args.signed_language)
-    result = _gloss_to_pose(sentences, args.lexicon, args.spoken_language, args.signed_language)
+    result = _gloss_to_pose(sentences, args.lexicon, args.spoken_language, args.signed_language,
+                            use_fingerspelling=not args.no_fingerspelling)
     _pose_to_video(result.pose, args.video)
 
     print("Text to gloss to pose to video")

--- a/spoken_to_signed/gloss_to_pose/__init__.py
+++ b/spoken_to_signed/gloss_to_pose/__init__.py
@@ -1,4 +1,5 @@
-from typing import Union
+from dataclasses import dataclass, field
+from typing import Optional, Union
 
 from pose_format import Pose
 
@@ -9,6 +10,15 @@ from .lookup import CSVPoseLookup as CSVPoseLookup
 from .lookup import PoseLookup
 
 
+@dataclass
+class GlossToPoseResult:
+    """Return type of gloss_to_pose(). Always contains a pose; token_coverages
+    is populated only when coverage_info=True is passed."""
+
+    pose: Pose
+    token_coverages: Optional[list[TokenCoverage]] = field(default=None)
+
+
 def gloss_to_pose(
     glosses: Gloss,
     pose_lookup: PoseLookup,
@@ -17,13 +27,14 @@ def gloss_to_pose(
     source: str = None,
     anonymize: Union[bool, Pose] = False,
     coverage_info: bool = False,
-) -> Union[Pose, tuple[Pose, list[TokenCoverage]]]:
+) -> GlossToPoseResult:
     # Transform the list of glosses into a list of poses
     result = pose_lookup.lookup_sequence(glosses, spoken_language, signed_language, source, coverage_info=coverage_info)
     if coverage_info:
-        poses, coverage = result
+        poses, token_coverages = result
     else:
         poses = result
+        token_coverages = None
 
     # Anonymize poses
     if anonymize:
@@ -48,4 +59,4 @@ def gloss_to_pose(
     # Concatenate the poses to create a single pose
     pose = concatenate_poses(poses)
 
-    return (pose, coverage) if coverage_info else pose
+    return GlossToPoseResult(pose=pose, token_coverages=token_coverages)

--- a/spoken_to_signed/gloss_to_pose/__init__.py
+++ b/spoken_to_signed/gloss_to_pose/__init__.py
@@ -4,6 +4,7 @@ from pose_format import Pose
 
 from ..text_to_gloss.types import Gloss
 from .concatenate import concatenate_poses
+from .coverage import TokenCoverage
 from .lookup import CSVPoseLookup as CSVPoseLookup
 from .lookup import PoseLookup
 
@@ -16,7 +17,7 @@ def gloss_to_pose(
     source: str = None,
     anonymize: Union[bool, Pose] = False,
     coverage_info: bool = False,
-) -> Union[Pose, tuple]:
+) -> Union[Pose, tuple[Pose, list[TokenCoverage]]]:
     # Transform the list of glosses into a list of poses
     result = pose_lookup.lookup_sequence(glosses, spoken_language, signed_language, source, coverage_info=coverage_info)
     if coverage_info:

--- a/spoken_to_signed/gloss_to_pose/__init__.py
+++ b/spoken_to_signed/gloss_to_pose/__init__.py
@@ -15,9 +15,14 @@ def gloss_to_pose(
     signed_language: str,
     source: str = None,
     anonymize: Union[bool, Pose] = False,
-) -> Pose:
+    coverage_info: bool = False,
+) -> Union[Pose, tuple]:
     # Transform the list of glosses into a list of poses
-    poses = pose_lookup.lookup_sequence(glosses, spoken_language, signed_language, source)
+    result = pose_lookup.lookup_sequence(glosses, spoken_language, signed_language, source, coverage_info=coverage_info)
+    if coverage_info:
+        poses, coverage = result
+    else:
+        poses = result
 
     # Anonymize poses
     if anonymize:
@@ -40,4 +45,6 @@ def gloss_to_pose(
             poses = [remove_appearance(pose) for pose in poses]
 
     # Concatenate the poses to create a single pose
-    return concatenate_poses(poses)
+    pose = concatenate_poses(poses)
+
+    return (pose, coverage) if coverage_info else pose

--- a/spoken_to_signed/gloss_to_pose/coverage.py
+++ b/spoken_to_signed/gloss_to_pose/coverage.py
@@ -7,7 +7,7 @@ from typing import Optional
 class TokenCoverage:
     word: Optional[str]
     gloss: str
-    matched: bool
+    exact_lexicon_match: bool
     coverage_type: Optional[str] = None  # "lexicon", "language_backup", "fingerspelling_backup", or None
     fingerspelled_keys: Optional[list[str]] = None  # set when coverage_type == "fingerspelling_backup"
 
@@ -21,7 +21,7 @@ class CoverageStats:
     def add_sentence(self, token_coverages: list[TokenCoverage], text: Optional[str] = None):
         self.sentences.append({"text": text, "tokens": [asdict(tc) for tc in token_coverages]})
         self.total_tokens += len(token_coverages)
-        self.matched_tokens += sum(1 for tc in token_coverages if tc.matched)
+        self.matched_tokens += sum(1 for tc in token_coverages if tc.exact_lexicon_match)
 
     @property
     def fraction(self) -> float:

--- a/spoken_to_signed/gloss_to_pose/coverage.py
+++ b/spoken_to_signed/gloss_to_pose/coverage.py
@@ -1,0 +1,38 @@
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+
+@dataclass
+class TokenCoverage:
+    word: Optional[str]
+    gloss: str
+    matched: bool
+    coverage_type: Optional[str] = None  # "lexicon", "language_backup", "fingerspelling_backup", or None
+    fingerspelled_keys: Optional[list[str]] = None  # set when coverage_type == "fingerspelling_backup"
+
+
+@dataclass
+class CoverageStats:
+    total_tokens: int = 0
+    matched_tokens: int = 0
+    sentences: list[dict] = field(default_factory=list)
+
+    def add_sentence(self, token_coverages: list[TokenCoverage], text: Optional[str] = None):
+        self.sentences.append({"text": text, "tokens": [asdict(tc) for tc in token_coverages]})
+        self.total_tokens += len(token_coverages)
+        self.matched_tokens += sum(1 for tc in token_coverages if tc.matched)
+
+    @property
+    def fraction(self) -> float:
+        return self.matched_tokens / self.total_tokens if self.total_tokens > 0 else 0.0
+
+    def save(self, path: str):
+        data = {
+            "total_tokens": self.total_tokens,
+            "matched_tokens": self.matched_tokens,
+            "coverage": self.fraction,
+            "sentences": self.sentences,
+        }
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)

--- a/spoken_to_signed/gloss_to_pose/coverage.py
+++ b/spoken_to_signed/gloss_to_pose/coverage.py
@@ -1,6 +1,19 @@
 import json
 from dataclasses import asdict, dataclass, field
+from enum import Enum
 from typing import Optional
+
+
+class CoverageType(str, Enum):
+    """Coverage type for a gloss token lookup result.
+
+    Inherits from str so that values serialize to JSON naturally and existing
+    string comparisons (e.g. == "lexicon") continue to work without changes.
+    """
+
+    LEXICON = "lexicon"
+    LANGUAGE_BACKUP = "language_backup"
+    FINGERSPELLING_BACKUP = "fingerspelling_backup"
 
 
 @dataclass
@@ -8,8 +21,8 @@ class TokenCoverage:
     word: Optional[str]
     gloss: str
     exact_lexicon_match: bool
-    coverage_type: Optional[str] = None  # "lexicon", "language_backup", "fingerspelling_backup", or None
-    fingerspelled_keys: Optional[list[str]] = None  # set when coverage_type == "fingerspelling_backup"
+    coverage_type: Optional[CoverageType] = None
+    fingerspelled_keys: Optional[list[str]] = None
 
 
 @dataclass

--- a/spoken_to_signed/gloss_to_pose/coverage.py
+++ b/spoken_to_signed/gloss_to_pose/coverage.py
@@ -14,6 +14,7 @@ class CoverageType(str, Enum):
     LEXICON = "lexicon"
     LANGUAGE_BACKUP = "language_backup"
     FINGERSPELLING_BACKUP = "fingerspelling_backup"
+    UNMATCHED = "unmatched"
 
 
 @dataclass

--- a/spoken_to_signed/gloss_to_pose/lookup/fingerspelling_lookup.py
+++ b/spoken_to_signed/gloss_to_pose/lookup/fingerspelling_lookup.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from pose_format import Pose
 
 from .. import CSVPoseLookup, concatenate_poses
+from ..coverage import CoverageType
 from .lookup import LookupResult
 
 
@@ -62,4 +63,4 @@ class FingerspellingPoseLookup(CSVPoseLookup):
         # hold the last letters longer to make it more readable
         poses[-1] = self.stretch_pose(poses[-1], 2)
 
-        return LookupResult(concatenate_poses(poses), "fingerspelling_backup", keys)
+        return LookupResult(concatenate_poses(poses), CoverageType.FINGERSPELLING_BACKUP, keys)

--- a/spoken_to_signed/gloss_to_pose/lookup/fingerspelling_lookup.py
+++ b/spoken_to_signed/gloss_to_pose/lookup/fingerspelling_lookup.py
@@ -31,7 +31,7 @@ class FingerspellingPoseLookup(CSVPoseLookup):
                     match_index = word.index(key)
 
                     yield from self.characters_lookup(word[:match_index], spoken_language, signed_language)
-                    yield self.get_pose(rows[key][0])
+                    yield key, self.get_pose(rows[key][0])
                     yield from self.characters_lookup(word[match_index + len(key) :], spoken_language, signed_language)
                     break
 
@@ -44,15 +44,18 @@ class FingerspellingPoseLookup(CSVPoseLookup):
         pose.body.fps = fps
         return pose
 
-    def lookup(self, word: str, gloss: str, spoken_language: str, signed_language: str, source: str = None) -> Pose:
+    def lookup(
+        self, word: str, gloss: str, spoken_language: str, signed_language: str, source: str = None
+    ) -> tuple[Pose, str, list[str]]:
         if spoken_language not in self.words_index or signed_language not in self.words_index[spoken_language]:
             raise FileNotFoundError(
                 f"Language pair {spoken_language} -> {signed_language} not supported for fingerspelling"
             )
 
-        poses = list(self.characters_lookup(word.lower(), spoken_language, signed_language))
+        keys, poses = zip(*self.characters_lookup(word.lower(), spoken_language, signed_language))
+        poses = list(poses)
 
         # hold the last letters longer to make it more readable
         poses[-1] = self.stretch_pose(poses[-1], 2)
 
-        return concatenate_poses(poses)
+        return concatenate_poses(poses), "fingerspelling_backup", keys

--- a/spoken_to_signed/gloss_to_pose/lookup/fingerspelling_lookup.py
+++ b/spoken_to_signed/gloss_to_pose/lookup/fingerspelling_lookup.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from pose_format import Pose
 
 from .. import CSVPoseLookup, concatenate_poses
+from .lookup import LookupResult
 
 
 class FingerspellingPoseLookup(CSVPoseLookup):
@@ -46,7 +47,7 @@ class FingerspellingPoseLookup(CSVPoseLookup):
 
     def lookup(
         self, word: str, gloss: str, spoken_language: str, signed_language: str, source: str = None
-    ) -> tuple[Pose, str, list[str]]:
+    ) -> LookupResult:
         if spoken_language not in self.words_index or signed_language not in self.words_index[spoken_language]:
             raise FileNotFoundError(
                 f"Language pair {spoken_language} -> {signed_language} not supported for fingerspelling"
@@ -58,4 +59,4 @@ class FingerspellingPoseLookup(CSVPoseLookup):
         # hold the last letters longer to make it more readable
         poses[-1] = self.stretch_pose(poses[-1], 2)
 
-        return concatenate_poses(poses), "fingerspelling_backup", keys
+        return LookupResult(concatenate_poses(poses), "fingerspelling_backup", keys)

--- a/spoken_to_signed/gloss_to_pose/lookup/fingerspelling_lookup.py
+++ b/spoken_to_signed/gloss_to_pose/lookup/fingerspelling_lookup.py
@@ -53,7 +53,10 @@ class FingerspellingPoseLookup(CSVPoseLookup):
                 f"Language pair {spoken_language} -> {signed_language} not supported for fingerspelling"
             )
 
-        keys, poses = zip(*self.characters_lookup(word.lower(), spoken_language, signed_language))
+        pairs = list(self.characters_lookup(word.lower(), spoken_language, signed_language))
+        if not pairs:
+            raise FileNotFoundError(f"No characters found for word '{word}' in fingerspelling lexicon")
+        keys, poses = zip(*pairs)
         poses = list(poses)
 
         # hold the last letters longer to make it more readable

--- a/spoken_to_signed/gloss_to_pose/lookup/lookup.py
+++ b/spoken_to_signed/gloss_to_pose/lookup/lookup.py
@@ -2,6 +2,7 @@ import math
 import os
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from typing import Optional
 
 from pose_format import Pose
 
@@ -82,7 +83,9 @@ class PoseLookup:
         # Return the highest priority row
         return rows[0]
 
-    def lookup(self, word: str, gloss: str, spoken_language: str, signed_language: str, source: str = None) -> Pose:
+    def lookup(
+        self, word: str, gloss: str, spoken_language: str, signed_language: str, source: str = None
+    ) -> tuple[Pose, str, Optional[list[str]]]:
         lookup_list = [
             (self.words_index, (spoken_language, signed_language, word)),
             (self.glosses_index, (spoken_language, signed_language, word)),
@@ -95,11 +98,17 @@ class PoseLookup:
                     lower_term = term.lower()
                     if lower_term in dict_index[spoken_language][signed_language]:
                         rows = dict_index[spoken_language][signed_language][lower_term]
-                        return self.get_pose(self.get_best_row(rows, term))
+                        return self.get_pose(self.get_best_row(rows, term)), "lexicon", None
 
         # Backup strategy: revert to backup sign language
         if signed_language in LANGUAGE_BACKUP:
-            return self.lookup(word, gloss, spoken_language, LANGUAGE_BACKUP[signed_language], source)
+            pose, coverage_type, sub_elements = self.lookup(
+                word, gloss, spoken_language, LANGUAGE_BACKUP[signed_language], source
+            )
+            # If found in the backup language's own lexicon, label as language_backup; otherwise keep the type
+            if coverage_type == "lexicon":
+                return pose, "language_backup", None
+            return pose, coverage_type, sub_elements
 
         # Backup strategy: revert to fingerspelling
         if self.backup is not None:
@@ -107,25 +116,49 @@ class PoseLookup:
 
         raise FileNotFoundError
 
-    def lookup_sequence(self, glosses: Gloss, spoken_language: str, signed_language: str, source: str = None):
+    def lookup_sequence(
+        self,
+        glosses: Gloss,
+        spoken_language: str,
+        signed_language: str,
+        source: str = None,
+        coverage_info: bool = False,
+    ):
         def lookup_pair(pair):
             word, gloss = pair
             if word == "":
-                return None
+                return None, None, None, word, gloss
 
             try:
-                return self.lookup(word, gloss, spoken_language, signed_language)
+                pose, coverage_type, sub_elements = self.lookup(word, gloss, spoken_language, signed_language)
+                return pose, coverage_type, sub_elements, word, gloss
             except FileNotFoundError as e:
                 print(e)
-                return None
+                return None, None, None, word, gloss
 
         with ThreadPoolExecutor() as executor:
-            results = executor.map(lookup_pair, glosses)
+            results = list(executor.map(lookup_pair, glosses))
 
-        poses = [result for result in results if result is not None]  # Filter out None results
+        poses = [pose for pose, _, _, _, _ in results if pose is not None]
 
         if len(poses) == 0:
             gloss_sequence = " ".join([f"{word}/{gloss}" for word, gloss in glosses])
             raise Exception(f"No poses found for {gloss_sequence}")
+
+        if coverage_info:
+            from spoken_to_signed.gloss_to_pose.coverage import TokenCoverage
+
+            token_coverages = [
+                TokenCoverage(
+                    word=word,
+                    gloss=gloss,
+                    matched=(coverage_type == "lexicon"),
+                    coverage_type=coverage_type,
+                    fingerspelled_keys=sub_elements,
+                )
+                for pose, coverage_type, sub_elements, word, gloss in results
+                if word != ""  # exclude empty/skipped tokens
+            ]
+            return poses, token_coverages
 
         return poses

--- a/spoken_to_signed/gloss_to_pose/lookup/lookup.py
+++ b/spoken_to_signed/gloss_to_pose/lookup/lookup.py
@@ -2,13 +2,29 @@ import math
 import os
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import NamedTuple, Optional
 
 from pose_format import Pose
 
 from spoken_to_signed.gloss_to_pose.languages import LANGUAGE_BACKUP
 from spoken_to_signed.gloss_to_pose.lookup.lru_cache import LRUCache
 from spoken_to_signed.text_to_gloss.types import Gloss
+
+
+class LookupResult(NamedTuple):
+    pose: Optional[Pose]
+    coverage_type: Optional[str]
+    sub_elements: Optional[list]
+
+
+@dataclass
+class PairResult:
+    word: str
+    gloss: str
+    pose: Optional[Pose] = field(default=None)
+    coverage_type: Optional[str] = field(default=None)
+    sub_elements: Optional[list] = field(default=None)
 
 
 class PoseLookup:
@@ -85,7 +101,7 @@ class PoseLookup:
 
     def lookup(
         self, word: str, gloss: str, spoken_language: str, signed_language: str, source: str = None
-    ) -> tuple[Pose, str, Optional[list[str]]]:
+    ) -> LookupResult:
         lookup_list = [
             (self.words_index, (spoken_language, signed_language, word)),
             (self.glosses_index, (spoken_language, signed_language, word)),
@@ -98,17 +114,15 @@ class PoseLookup:
                     lower_term = term.lower()
                     if lower_term in dict_index[spoken_language][signed_language]:
                         rows = dict_index[spoken_language][signed_language][lower_term]
-                        return self.get_pose(self.get_best_row(rows, term)), "lexicon", None
+                        return LookupResult(self.get_pose(self.get_best_row(rows, term)), "lexicon", None)
 
         # Backup strategy: revert to backup sign language
         if signed_language in LANGUAGE_BACKUP:
-            pose, coverage_type, sub_elements = self.lookup(
-                word, gloss, spoken_language, LANGUAGE_BACKUP[signed_language], source
-            )
+            result = self.lookup(word, gloss, spoken_language, LANGUAGE_BACKUP[signed_language], source)
             # If found in the backup language's own lexicon, label as language_backup; otherwise keep the type
-            if coverage_type == "lexicon":
-                return pose, "language_backup", None
-            return pose, coverage_type, sub_elements
+            if result.coverage_type == "lexicon":
+                return LookupResult(result.pose, "language_backup", None)
+            return result
 
         # Backup strategy: revert to fingerspelling
         if self.backup is not None:
@@ -127,19 +141,25 @@ class PoseLookup:
         def lookup_pair(pair):
             word, gloss = pair
             if word == "":
-                return None, None, None, word, gloss
+                return PairResult(word=word, gloss=gloss)
 
             try:
-                pose, coverage_type, sub_elements = self.lookup(word, gloss, spoken_language, signed_language)
-                return pose, coverage_type, sub_elements, word, gloss
+                result = self.lookup(word, gloss, spoken_language, signed_language)
+                return PairResult(
+                    word=word,
+                    gloss=gloss,
+                    pose=result.pose,
+                    coverage_type=result.coverage_type,
+                    sub_elements=result.sub_elements,
+                )
             except FileNotFoundError as e:
                 print(e)
-                return None, None, None, word, gloss
+                return PairResult(word=word, gloss=gloss)
 
         with ThreadPoolExecutor() as executor:
             results = list(executor.map(lookup_pair, glosses))
 
-        poses = [pose for pose, _, _, _, _ in results if pose is not None]
+        poses = [r.pose for r in results if r.pose is not None]
 
         if len(poses) == 0:
             gloss_sequence = " ".join([f"{word}/{gloss}" for word, gloss in glosses])
@@ -150,14 +170,14 @@ class PoseLookup:
 
             token_coverages = [
                 TokenCoverage(
-                    word=word,
-                    gloss=gloss,
-                    matched=(coverage_type == "lexicon"),
-                    coverage_type=coverage_type,
-                    fingerspelled_keys=sub_elements,
+                    word=r.word,
+                    gloss=r.gloss,
+                    matched=(r.coverage_type == "lexicon"),
+                    coverage_type=r.coverage_type,
+                    fingerspelled_keys=r.sub_elements,
                 )
-                for pose, coverage_type, sub_elements, word, gloss in results
-                if word != ""  # exclude empty/skipped tokens
+                for r in results
+                if r.word != ""  # exclude empty/skipped tokens
             ]
             return poses, token_coverages
 

--- a/spoken_to_signed/gloss_to_pose/lookup/lookup.py
+++ b/spoken_to_signed/gloss_to_pose/lookup/lookup.py
@@ -7,6 +7,7 @@ from typing import NamedTuple, Optional
 
 from pose_format import Pose
 
+from spoken_to_signed.gloss_to_pose.coverage import CoverageType
 from spoken_to_signed.gloss_to_pose.languages import LANGUAGE_BACKUP
 from spoken_to_signed.gloss_to_pose.lookup.lru_cache import LRUCache
 from spoken_to_signed.text_to_gloss.types import Gloss
@@ -14,7 +15,7 @@ from spoken_to_signed.text_to_gloss.types import Gloss
 
 class LookupResult(NamedTuple):
     pose: Optional[Pose]
-    coverage_type: Optional[str]
+    coverage_type: Optional[CoverageType]
     sub_elements: Optional[list]
 
 
@@ -114,14 +115,14 @@ class PoseLookup:
                     lower_term = term.lower()
                     if lower_term in dict_index[spoken_language][signed_language]:
                         rows = dict_index[spoken_language][signed_language][lower_term]
-                        return LookupResult(self.get_pose(self.get_best_row(rows, term)), "lexicon", None)
+                        return LookupResult(self.get_pose(self.get_best_row(rows, term)), CoverageType.LEXICON, None)
 
         # Backup strategy: revert to backup sign language
         if signed_language in LANGUAGE_BACKUP:
             result = self.lookup(word, gloss, spoken_language, LANGUAGE_BACKUP[signed_language], source)
             # If found in the backup language's own lexicon, label as language_backup; otherwise keep the type
-            if result.coverage_type == "lexicon":
-                return LookupResult(result.pose, "language_backup", None)
+            if result.coverage_type == CoverageType.LEXICON:
+                return LookupResult(result.pose, CoverageType.LANGUAGE_BACKUP, None)
             return result
 
         # Backup strategy: revert to fingerspelling
@@ -172,7 +173,7 @@ class PoseLookup:
                 TokenCoverage(
                     word=r.word,
                     gloss=r.gloss,
-                    exact_lexicon_match=(r.coverage_type == "lexicon"),
+                    exact_lexicon_match=(r.coverage_type == CoverageType.LEXICON),
                     coverage_type=r.coverage_type,
                     fingerspelled_keys=r.sub_elements,
                 )

--- a/spoken_to_signed/gloss_to_pose/lookup/lookup.py
+++ b/spoken_to_signed/gloss_to_pose/lookup/lookup.py
@@ -172,7 +172,7 @@ class PoseLookup:
                 TokenCoverage(
                     word=r.word,
                     gloss=r.gloss,
-                    matched=(r.coverage_type == "lexicon"),
+                    exact_lexicon_match=(r.coverage_type == "lexicon"),
                     coverage_type=r.coverage_type,
                     fingerspelled_keys=r.sub_elements,
                 )

--- a/spoken_to_signed/gloss_to_pose/lookup/lookup.py
+++ b/spoken_to_signed/gloss_to_pose/lookup/lookup.py
@@ -7,7 +7,7 @@ from typing import NamedTuple, Optional
 
 from pose_format import Pose
 
-from spoken_to_signed.gloss_to_pose.coverage import CoverageType
+from spoken_to_signed.gloss_to_pose.coverage import CoverageType, TokenCoverage
 from spoken_to_signed.gloss_to_pose.languages import LANGUAGE_BACKUP
 from spoken_to_signed.gloss_to_pose.lookup.lru_cache import LRUCache
 from spoken_to_signed.text_to_gloss.types import Gloss
@@ -167,8 +167,6 @@ class PoseLookup:
             raise Exception(f"No poses found for {gloss_sequence}")
 
         if coverage_info:
-            from spoken_to_signed.gloss_to_pose.coverage import TokenCoverage
-
             token_coverages = [
                 TokenCoverage(
                     word=r.word,

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,0 +1,74 @@
+"""Unit tests for CoverageStats and TokenCoverage."""
+import pytest
+
+from spoken_to_signed.gloss_to_pose.coverage import CoverageStats, CoverageType, TokenCoverage
+
+
+def _token(gloss: str, coverage_type=None, exact_lexicon_match: bool = False) -> TokenCoverage:
+    return TokenCoverage(word=gloss, gloss=gloss, exact_lexicon_match=exact_lexicon_match, coverage_type=coverage_type)
+
+
+class TestCoverageStatsFraction:
+    def test_no_tokens_returns_zero(self):
+        stats = CoverageStats()
+        assert stats.fraction == 0.0
+
+    def test_all_matched(self):
+        stats = CoverageStats()
+        tokens = [_token("a", CoverageType.LEXICON, exact_lexicon_match=True)] * 3
+        stats.add_sentence(tokens)
+        assert stats.fraction == 1.0
+
+    def test_none_matched(self):
+        stats = CoverageStats()
+        tokens = [_token("a")] * 4
+        stats.add_sentence(tokens)
+        assert stats.fraction == 0.0
+
+    def test_partial_match(self):
+        stats = CoverageStats()
+        tokens = [
+            _token("a", CoverageType.LEXICON, exact_lexicon_match=True),
+            _token("b", CoverageType.LEXICON, exact_lexicon_match=True),
+            _token("c"),
+        ]
+        stats.add_sentence(tokens)
+        assert stats.fraction == pytest.approx(2 / 3)
+
+    def test_accumulates_across_sentences(self):
+        stats = CoverageStats()
+        stats.add_sentence([_token("a", CoverageType.LEXICON, exact_lexicon_match=True)])
+        stats.add_sentence([_token("b"), _token("c")])
+        assert stats.total_tokens == 3
+        assert stats.matched_tokens == 1
+        assert stats.fraction == pytest.approx(1 / 3)
+
+
+class TestCoverageStatsAddSentence:
+    def test_empty_sentence(self):
+        stats = CoverageStats()
+        stats.add_sentence([])
+        assert stats.total_tokens == 0
+        assert stats.matched_tokens == 0
+
+    def test_sentence_text_stored(self):
+        stats = CoverageStats()
+        stats.add_sentence([_token("Danke")], text="Danke.")
+        assert stats.sentences[0]["text"] == "Danke."
+
+    def test_sentence_text_none_when_omitted(self):
+        stats = CoverageStats()
+        stats.add_sentence([_token("Danke")])
+        assert stats.sentences[0]["text"] is None
+
+
+class TestCoverageType:
+    def test_values_are_strings(self):
+        assert CoverageType.LEXICON == "lexicon"
+        assert CoverageType.LANGUAGE_BACKUP == "language_backup"
+        assert CoverageType.FINGERSPELLING_BACKUP == "fingerspelling_backup"
+        assert CoverageType.UNMATCHED == "unmatched"
+
+    def test_string_comparison(self):
+        assert CoverageType.LEXICON == "lexicon"
+        assert "lexicon" == CoverageType.LEXICON

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import tempfile
 from pathlib import Path
@@ -30,3 +31,60 @@ def test_text_to_gloss_to_pose():
             pose = Pose.read(f.read())
 
         assert pose.body.data.shape[0] > 0, "Pose has no frames"
+
+
+def test_text_to_gloss_to_pose_coverage_info():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pose_path = Path(tmp_dir) / "output.pose"
+
+        result = subprocess.run(
+            [
+                "text_to_gloss_to_pose",
+                "--text", "Kleine Kinder essen Pizza in Zürich.",
+                "--glosser", "simple",
+                "--lexicon", "assets/dummy_lexicon",
+                "--spoken-language", "de",
+                "--signed-language", "sgg",
+                "--pose", str(pose_path),
+                "--coverage-info",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"Command failed: {result.stderr}"
+        assert "Coverage:" in result.stdout, "Coverage summary not printed"
+
+
+def test_text_to_gloss_to_pose_coverage_stats():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pose_path = Path(tmp_dir) / "output.pose"
+        stats_path = Path(tmp_dir) / "coverage.json"
+
+        result = subprocess.run(
+            [
+                "text_to_gloss_to_pose",
+                "--text", "Kleine Kinder essen Pizza in Zürich.",
+                "--glosser", "simple",
+                "--lexicon", "assets/dummy_lexicon",
+                "--spoken-language", "de",
+                "--signed-language", "sgg",
+                "--pose", str(pose_path),
+                "--coverage-stats", str(stats_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"Command failed: {result.stderr}"
+        assert stats_path.exists(), "Coverage stats file was not created"
+
+        with open(stats_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert "coverage" in data
+        assert "total_tokens" in data
+        assert "matched_tokens" in data
+        assert "sentences" in data
+        assert len(data["sentences"]) == 1
+        assert len(data["sentences"][0]["tokens"]) > 0


### PR DESCRIPTION
This PR introduces an optional CLI flag (`--no-use-fingerspelling`) that allows users to disable the fingerspelling fallback during gloss-to-pose lookup.

The change is intentionally limited to the CLI layer (`spoken_to_signed/bin.py`). When the flag is not provided, the default behavior remains unchanged and fingerspelling is still used as a fallback mechanism.

This PR isolates the fingerspelling-related change from previous, broader PR (#52).
